### PR TITLE
feat: Add GitHub Actions workflow for building the application

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build ENvision Electron App
+
+# This workflow runs on pushes to the main branch and on any pull request
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+jobs:
+  build:
+    # Use a Windows runner to build the Windows .exe
+    runs-on: windows-latest
+
+    steps:
+      - name: 1. Check out the repository code
+        uses: actions/checkout@v4
+
+      - name: 2. Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' # Use a current LTS version of Node.js
+
+      - name: 3. Install dependencies
+        run: npm install
+
+      - name: 4. Build the application
+        run: npm run dist
+
+      - name: 5. Upload the build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ENvision-windows-build # The name of the downloadable file
+          path: dist/ # The folder containing the built .exe


### PR DESCRIPTION
This commit adds a GitHub Actions workflow to automatically build the ENvision Electron application.

The workflow is configured to:
- Run on pushes to the main branch and on pull requests.
- Use a Windows runner to build the Windows executable.
- Set up Node.js and install dependencies.
- Build the application using the `npm run dist` script.
- Upload the built executable as a downloadable artifact.

This will allow for automated testing of the build process and provide a way to download the application for manual testing.